### PR TITLE
Fix criteria for translating a function to an action

### DIFF
--- a/src/boilerplate.rs
+++ b/src/boilerplate.rs
@@ -154,7 +154,7 @@ pub fn post_items(ctx: &Context) -> String {
         .join(",\n");
 
     let special_actions = ["execute", "instantiate", "reply"];
-    let reply = if !ctx.stateful_ops.contains(&"reply".to_string()) {
+    let reply = if !ctx.ops_with_mutability.contains(&"reply".to_string()) {
         // Generate default reply to be given for the message handler
         "
 
@@ -166,7 +166,7 @@ pub fn post_items(ctx: &Context) -> String {
     };
 
     let actions = ctx
-        .stateful_ops
+        .ops_with_mutability
         .iter()
         .filter(|op| !special_actions.contains(&op.as_str()))
         .map(|op| format!("{op}_action"))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ fn traslate_items(tcx: TyCtxt, crate_name: &str, items: Vec<&rustc_hir::Item>) {
             },
         )]),
         structs: HashMap::new(),
-        stateful_ops: vec![],
+        ops_with_mutability: vec![],
         contract_state: vec![],
         // scoped
         record_fields: vec![],

--- a/src/types.rs
+++ b/src/types.rs
@@ -33,7 +33,7 @@ pub struct Context<'tcx> {
     pub message_type_for_action: HashMap<String, String>,
     pub constructors: HashMap<String, Constructor>,
     pub structs: HashMap<String, Vec<Field>>,
-    pub stateful_ops: Vec<String>,
+    pub ops_with_mutability: Vec<String>,
     pub tcx: TyCtxt<'tcx>,
     pub contract_state: Vec<(String, String)>,
     // scoped


### PR DESCRIPTION
Hello :octocat: 

Closes https://github.com/informalsystems/cosmwasm-to-quint/issues/15

We now only translate functions with `DepsMut` as actions, while functions with `Deps` are translated to pure helper definitions.

This doesn't have an impact on any CTF contract (so, in our snapshot tests), but it fixes a problem that both @p-offtermatt and @ivan-gavran hit. I manually checked that this fixes those.