### PR TITLE
Avoid useless errors in generated files

### DIFF
--- a/src/boilerplate.rs
+++ b/src/boilerplate.rs
@@ -126,6 +126,10 @@ pub fn init_value_for_type(ctx: &Context, ty: String) -> String {
         return "[]".to_string();
     }
 
+    if ty.starts_with("Option") {
+        return "None".to_string();
+    }
+
     let typ = ty.split('[').next().unwrap();
     if ctx.structs.contains_key(typ) {
         // Type is a struct, initialize fields recursively
@@ -196,7 +200,7 @@ pub fn post_items(ctx: &Context) -> String {
     {contract_state}
   }}
 
-  pure val init_contract_state = {{
+  pure val init_contract_state: ContractState = {{
     {initializer}
   }}
 

--- a/src/boilerplate.rs
+++ b/src/boilerplate.rs
@@ -87,7 +87,7 @@ pub fn initializers(ctx: &Context) -> String {
         "
   pure val init_bank_state = ADDRESSES.mapBy(_ => DENOMS.mapBy(_ => MAX_AMOUNT))
 
-  val env_val = {{ block: {{ time: time }} }}
+  val env_val = {{ block: {{ time: time, height: 1 }} }} // TODO: Add a height var if you need it
 
   action init = {{
     // TODO: Change next line according to fund expectations
@@ -100,7 +100,7 @@ pub fn initializers(ctx: &Context) -> String {
     val info = {{ sender: sender, funds: funds }}
 
     pure val message: InstantiateMsg = {}
-    pure val r = instantiate(init_contract_state, {{ block: {{ time: 0 }} }}, info, message)
+    pure val r = instantiate(init_contract_state, {{ block: {{ time: 0, height: 1 }} }}, info, message)
 
     all {{
       contract_state' = r._2,

--- a/src/boilerplate.rs
+++ b/src/boilerplate.rs
@@ -126,9 +126,10 @@ pub fn init_value_for_type(ctx: &Context, ty: String) -> String {
         return "[]".to_string();
     }
 
-    if ctx.structs.contains_key(&ty) {
+    let typ = ty.split('[').next().unwrap();
+    if ctx.structs.contains_key(typ) {
         // Type is a struct, initialize fields recursively
-        let fields = ctx.structs.get(&ty).unwrap();
+        let fields = ctx.structs.get(typ).unwrap();
         let struct_value = fields
             .iter()
             .map(|field| {
@@ -139,17 +140,17 @@ pub fn init_value_for_type(ctx: &Context, ty: String) -> String {
                 )
             })
             .collect_vec()
-            .join(",");
+            .join(", ");
         return format!("{{ {} }}", struct_value);
     }
 
-    match ty.as_str() {
+    match typ {
         "str" => "\"\"".to_string(),
         "int" => "0".to_string(),
         "Addr" => "\"s1\"".to_string(),
         _ => {
             eprintln!("No init value for type: {ty}");
-            "<missing-type>".to_string()
+            "\"<missing-value>\"".to_string()
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,8 @@ fn translate_items(tcx: TyCtxt, crate_name: &str, items: Vec<&rustc_hir::Item>) 
             ("denom".to_string(), "str".to_string()),
             ("amount".to_string(), "int".to_string()),
         ],
+        enums: HashMap::new(),
+        type_aliases: HashMap::new(),
         // scoped
         record_fields: vec![],
         struct_fields: vec![],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,7 @@ fn translate_items(tcx: TyCtxt, crate_name: &str, items: Vec<&rustc_hir::Item>) 
         record_fields: vec![],
         struct_fields: vec![],
         pat_fields: vec![],
+        generics: vec![],
         current_item_name: "".to_string(),
     };
 

--- a/src/quint-lib-files/cw_types.qnt
+++ b/src/quint-lib-files/cw_types.qnt
@@ -65,7 +65,7 @@ module cw_types {
     gas_limit: None,
   }
 
-  pure def SubMsg_reply_on_sucess(msg: CosmosMsg, id: int): SubMsg = {
+  pure def SubMsg_reply_on_success(msg: CosmosMsg, id: int): SubMsg = {
     __reply_on(msg, id, ReplyOn_Success)
   }
 
@@ -133,7 +133,8 @@ module cw_types {
     querier: TODO,
   }
 
-  type Env = { block: { time: int /*, height: int */ } } // TODO
+  type BlockInfo = { time: int, height: int }
+  type Env = { block: BlockInfo }
 
   type Coin = {
     denom: str,
@@ -149,4 +150,16 @@ module cw_types {
     | FromStr(str)
     | FromInt(int)
     | FromListInt(List[int])
+
+  // These shouldn't be actually used, but they are here for completion
+  type MultiIndex[ik, t, pk] = ()
+  type IndexedMap[k, t i] = ()
+
+  type StdError = str
+  type StdResult[a] = Result[a, StdError]
+
+  // There's no dynamic dispatch in Quint, so the best we can do is to have a
+  // special string argument to identify a behavior and then have the
+  // implementation depend on it
+  type TraitObject = str
 }

--- a/src/quint-lib-files/cw_utils.qnt
+++ b/src/quint-lib-files/cw_utils.qnt
@@ -4,6 +4,19 @@
 module cw_utils {
   import cw_types.* from "./cw_types"
 
+  type Expiration =
+    // AtHeight will expire when `env.block.height` >= height
+    | Expiration_AtHeight(int)
+    // AtTime will expire when `env.block.time` >= time
+    | Expiration_AtTime(int)
+    // Never will never expire. Used to express the empty variant
+    | Expiration_Never
+
+  type Duration =
+    | Duration_Height(int)
+    // Time in seconds
+    | Duration_Time(int)
+
   def one_coin(info: MessageInfo): Result[Coin, ContractError] = {
     if (info.funds.indices().size() == 0) {
       Err("No funds")

--- a/src/state_extraction.rs
+++ b/src/state_extraction.rs
@@ -1,7 +1,9 @@
 use itertools::Itertools;
+use regex::Regex;
 use rustc_span::{symbol::Ident, Symbol};
 
 use crate::{translate::Translatable, types::Context};
+extern crate regex;
 
 // State extraction is the only place where we need to deal with
 // rustc_middle::ty::Ty. This is the type given by typeck, which is the only way
@@ -11,19 +13,30 @@ use crate::{translate::Translatable, types::Context};
 impl Translatable for rustc_middle::ty::Ty<'_> {
     fn translate(&self, ctx: &mut Context) -> String {
         // FIXME: This should be quite unstable, but I couldn't figure out how to navigate `ty` here
+
         let var_name = &format!("{:#?}", self);
-        let name = var_name
-            .split("::")
-            .last()
-            .unwrap()
+        let name_core = var_name
+            .clone()
             .split(' ')
             .last()
             .unwrap()
             .split(')')
             .next()
-            .unwrap();
+            .unwrap()
+            .to_string();
 
-        Ident::with_dummy_span(Symbol::intern(name)).translate(ctx)
+        // The name_core can look like namespace::namespace::type<namespace::namespace::type_arg>
+        // The following regex replacement has the goal of transforming it into type<type_arg>
+        let re = Regex::new(r"(\w+::)*(\w+)(<(\w+::)*(\w+)>)?").unwrap();
+        let name = re.replace(name_core.as_str(), |caps: &regex::Captures| {
+            if let Some(m) = caps.get(4) {
+                format!("{}[{}]", &caps[2], m.as_str())
+            } else {
+                caps[2].to_string()
+            }
+        });
+
+        Ident::with_dummy_span(Symbol::intern(name.to_string().as_str())).translate(ctx)
     }
 }
 impl Translatable for rustc_middle::ty::GenericArg<'_> {

--- a/src/state_extraction.rs
+++ b/src/state_extraction.rs
@@ -29,7 +29,7 @@ impl Translatable for rustc_middle::ty::Ty<'_> {
         // The following regex replacement has the goal of transforming it into type<type_arg>
         let re = Regex::new(r"(\w+::)*(\w+)(<(\w+::)*(\w+)>)?").unwrap();
         let name = re.replace(name_core.as_str(), |caps: &regex::Captures| {
-            if let Some(m) = caps.get(4) {
+            if let Some(m) = caps.get(5) {
                 format!("{}[{}]", &caps[2], m.as_str())
             } else {
                 caps[2].to_string()

--- a/src/types.rs
+++ b/src/types.rs
@@ -46,6 +46,7 @@ pub struct Context<'tcx, 'c> {
     pub record_fields: Vec<String>,
     pub struct_fields: Vec<Field>,
     pub pat_fields: Vec<String>,
+    pub generics: Vec<String>,
     pub current_item_name: String,
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -38,6 +38,8 @@ pub struct Context<'tcx, 'c> {
     pub tcx: TyCtxt<'tcx>,
     pub contract_state: Vec<(String, String)>,
     pub nondet_picks: Vec<(String, String)>,
+    pub enums: HashMap<String, Vec<String>>,
+    pub type_aliases: HashMap<String, String>,
     // scoped
     // FIXME: This should be a stack to account for nested scopes.
     // No need to worry about nested scopes for stub generation.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -36,6 +36,8 @@ fn run(dir: &str, f: impl FnOnce(&mut Command)) -> Result<String> {
     f(&mut cmd);
 
     let _ = fs::remove_dir_all(ws.join("target"));
+    let _ = fs::remove_dir_all(ws.join("quint"));
+    let _ = fs::remove_dir_all(ws.join("tests"));
 
     let output = cmd.output().context("Process failed")?;
     ensure!(

--- a/tests/snapshots/integration_tests__ctf01.snap
+++ b/tests/snapshots/integration_tests__ctf01.snap
@@ -78,7 +78,7 @@ module oaksecurity_cosmwasm_ctf_01 {
     lockups: int -> Lockup
   }
 
-  pure val init_contract_state = {
+  pure val init_contract_state: ContractState = {
     last_id: 0,
     lockups: Map()
   }

--- a/tests/snapshots/integration_tests__ctf01.snap
+++ b/tests/snapshots/integration_tests__ctf01.snap
@@ -96,7 +96,7 @@ module oaksecurity_cosmwasm_ctf_01 {
 
   pure val init_bank_state = ADDRESSES.mapBy(_ => DENOMS.mapBy(_ => MAX_AMOUNT))
 
-  val env_val = { block: { time: time } }
+  val env_val = { block: { time: time, height: 1 } } // TODO: Add a height var if you need it
 
   action init = {
     // TODO: Change next line according to fund expectations
@@ -109,7 +109,7 @@ module oaksecurity_cosmwasm_ctf_01 {
     val info = { sender: sender, funds: funds }
 
     pure val message: InstantiateMsg = { count: 0 }
-    pure val r = instantiate(init_contract_state, { block: { time: 0 } }, info, message)
+    pure val r = instantiate(init_contract_state, { block: { time: 0, height: 1 } }, info, message)
 
     all {
       contract_state' = r._2,

--- a/tests/snapshots/integration_tests__ctf02.snap
+++ b/tests/snapshots/integration_tests__ctf02.snap
@@ -106,7 +106,7 @@ module oaksecurity_cosmwasm_ctf_02 {
     voting_power: Addr -> UserInfo
   }
 
-  pure val init_contract_state = {
+  pure val init_contract_state: ContractState = {
     voting_power: Map()
   }
 

--- a/tests/snapshots/integration_tests__ctf02.snap
+++ b/tests/snapshots/integration_tests__ctf02.snap
@@ -125,7 +125,7 @@ module oaksecurity_cosmwasm_ctf_02 {
 
   pure val init_bank_state = ADDRESSES.mapBy(_ => DENOMS.mapBy(_ => MAX_AMOUNT))
 
-  val env_val = { block: { time: time } }
+  val env_val = { block: { time: time, height: 1 } } // TODO: Add a height var if you need it
 
   action init = {
     // TODO: Change next line according to fund expectations
@@ -138,7 +138,7 @@ module oaksecurity_cosmwasm_ctf_02 {
     val info = { sender: sender, funds: funds }
 
     pure val message: InstantiateMsg = {  }
-    pure val r = instantiate(init_contract_state, { block: { time: 0 } }, info, message)
+    pure val r = instantiate(init_contract_state, { block: { time: 0, height: 1 } }, info, message)
 
     all {
       contract_state' = r._2,

--- a/tests/snapshots/integration_tests__ctf03.snap
+++ b/tests/snapshots/integration_tests__ctf03.snap
@@ -133,7 +133,7 @@ module flash_loan {
 
   pure val init_bank_state = ADDRESSES.mapBy(_ => DENOMS.mapBy(_ => MAX_AMOUNT))
 
-  val env_val = { block: { time: time } }
+  val env_val = { block: { time: time, height: 1 } } // TODO: Add a height var if you need it
 
   action init = {
     // TODO: Change next line according to fund expectations
@@ -146,7 +146,7 @@ module flash_loan {
     val info = { sender: sender, funds: funds }
 
     pure val message: InstantiateMsg = <missing-type>
-    pure val r = instantiate(init_contract_state, { block: { time: 0 } }, info, message)
+    pure val r = instantiate(init_contract_state, { block: { time: 0, height: 1 } }, info, message)
 
     all {
       contract_state' = r._2,
@@ -270,7 +270,7 @@ module mock_arb {
 
   pure val init_bank_state = ADDRESSES.mapBy(_ => DENOMS.mapBy(_ => MAX_AMOUNT))
 
-  val env_val = { block: { time: time } }
+  val env_val = { block: { time: time, height: 1 } } // TODO: Add a height var if you need it
 
   action init = {
     // TODO: Change next line according to fund expectations
@@ -283,7 +283,7 @@ module mock_arb {
     val info = { sender: sender, funds: funds }
 
     pure val message: InstantiateMsg = <missing-type>
-    pure val r = instantiate(init_contract_state, { block: { time: 0 } }, info, message)
+    pure val r = instantiate(init_contract_state, { block: { time: 0, height: 1 } }, info, message)
 
     all {
       contract_state' = r._2,
@@ -405,7 +405,7 @@ module proxy {
 
   pure val init_bank_state = ADDRESSES.mapBy(_ => DENOMS.mapBy(_ => MAX_AMOUNT))
 
-  val env_val = { block: { time: time } }
+  val env_val = { block: { time: time, height: 1 } } // TODO: Add a height var if you need it
 
   action init = {
     // TODO: Change next line according to fund expectations
@@ -418,7 +418,7 @@ module proxy {
     val info = { sender: sender, funds: funds }
 
     pure val message: InstantiateMsg = <missing-type>
-    pure val r = instantiate(init_contract_state, { block: { time: 0 } }, info, message)
+    pure val r = instantiate(init_contract_state, { block: { time: 0, height: 1 } }, info, message)
 
     all {
       contract_state' = r._2,

--- a/tests/snapshots/integration_tests__ctf03.snap
+++ b/tests/snapshots/integration_tests__ctf03.snap
@@ -112,7 +112,7 @@ module flash_loan {
     flash_loan: FlashLoanState
   }
 
-  pure val init_contract_state = {
+  pure val init_contract_state: ContractState = {
     config: "<missing-value>",
     flash_loan: "<missing-value>"
   }
@@ -254,7 +254,7 @@ module mock_arb {
     config: Config
   }
 
-  pure val init_contract_state = {
+  pure val init_contract_state: ContractState = {
     config: "<missing-value>"
   }
 
@@ -389,7 +389,7 @@ module proxy {
     config: Config
   }
 
-  pure val init_contract_state = {
+  pure val init_contract_state: ContractState = {
     config: "<missing-value>"
   }
 

--- a/tests/snapshots/integration_tests__ctf03.snap
+++ b/tests/snapshots/integration_tests__ctf03.snap
@@ -113,8 +113,8 @@ module flash_loan {
   }
 
   pure val init_contract_state = {
-    config: <missing-type>,
-    flash_loan: <missing-type>
+    config: "<missing-value>",
+    flash_loan: "<missing-value>"
   }
 
   action execute_step = all {
@@ -145,7 +145,7 @@ module flash_loan {
     val funds = [{ denom: denom, amount: amount }]
     val info = { sender: sender, funds: funds }
 
-    pure val message: InstantiateMsg = <missing-type>
+    pure val message: InstantiateMsg = "<missing-value>"
     pure val r = instantiate(init_contract_state, { block: { time: 0, height: 1 } }, info, message)
 
     all {
@@ -255,7 +255,7 @@ module mock_arb {
   }
 
   pure val init_contract_state = {
-    config: <missing-type>
+    config: "<missing-value>"
   }
 
   action execute_step = all {
@@ -282,7 +282,7 @@ module mock_arb {
     val funds = [{ denom: denom, amount: amount }]
     val info = { sender: sender, funds: funds }
 
-    pure val message: InstantiateMsg = <missing-type>
+    pure val message: InstantiateMsg = "<missing-value>"
     pure val r = instantiate(init_contract_state, { block: { time: 0, height: 1 } }, info, message)
 
     all {
@@ -390,7 +390,7 @@ module proxy {
   }
 
   pure val init_contract_state = {
-    config: <missing-type>
+    config: "<missing-value>"
   }
 
   action execute_step = all {
@@ -417,7 +417,7 @@ module proxy {
     val funds = [{ denom: denom, amount: amount }]
     val info = { sender: sender, funds: funds }
 
-    pure val message: InstantiateMsg = <missing-type>
+    pure val message: InstantiateMsg = "<missing-value>"
     pure val r = instantiate(init_contract_state, { block: { time: 0, height: 1 } }, info, message)
 
     all {

--- a/tests/snapshots/integration_tests__ctf04.snap
+++ b/tests/snapshots/integration_tests__ctf04.snap
@@ -77,7 +77,7 @@ module oaksecurity_cosmwasm_ctf_04 {
     balances: Addr -> Balance
   }
 
-  pure val init_contract_state = {
+  pure val init_contract_state: ContractState = {
     config: { total_supply: 0 },
     balances: Map()
   }

--- a/tests/snapshots/integration_tests__ctf04.snap
+++ b/tests/snapshots/integration_tests__ctf04.snap
@@ -95,7 +95,7 @@ module oaksecurity_cosmwasm_ctf_04 {
 
   pure val init_bank_state = ADDRESSES.mapBy(_ => DENOMS.mapBy(_ => MAX_AMOUNT))
 
-  val env_val = { block: { time: time } }
+  val env_val = { block: { time: time, height: 1 } } // TODO: Add a height var if you need it
 
   action init = {
     // TODO: Change next line according to fund expectations
@@ -108,7 +108,7 @@ module oaksecurity_cosmwasm_ctf_04 {
     val info = { sender: sender, funds: funds }
 
     pure val message: InstantiateMsg = { offset: 0 }
-    pure val r = instantiate(init_contract_state, { block: { time: 0 } }, info, message)
+    pure val r = instantiate(init_contract_state, { block: { time: 0, height: 1 } }, info, message)
 
     all {
       contract_state' = r._2,

--- a/tests/snapshots/integration_tests__ctf05.snap
+++ b/tests/snapshots/integration_tests__ctf05.snap
@@ -86,7 +86,7 @@ module oaksecurity_cosmwasm_ctf_05 {
   action owner_action_action = {
     // TODO: Change next line according to fund expectations
     pure val max_funds = MAX_AMOUNT
-    nondet message_msg: CosmosMsg = <missing-nondet-value>.oneOf()
+    nondet message_msg: CosmosMsg = "<missing-nondet-value>".oneOf()
     pure val message: ExecuteMsg = ExecuteMsg_OwnerAction({ msg: message_msg })
     execute_message(message, max_funds)
   }
@@ -129,7 +129,7 @@ module oaksecurity_cosmwasm_ctf_05 {
     pure val message: ExecuteMsg = ExecuteMsg_DropOwnershipProposal
     execute_message(message, max_funds)
   }
-  pure def assert_owner(store: <missing-type>, sender: Addr): Result[(), ContractError] = Ok(())
+  pure def assert_owner(store: TraitObject, sender: Addr): Result[(), ContractError] = Ok(())
   pure val DENOM = "uawesome"
 
   type ContractState = {
@@ -159,7 +159,7 @@ module oaksecurity_cosmwasm_ctf_05 {
 
   pure val init_bank_state = ADDRESSES.mapBy(_ => DENOMS.mapBy(_ => MAX_AMOUNT))
 
-  val env_val = { block: { time: time } }
+  val env_val = { block: { time: time, height: 1 } } // TODO: Add a height var if you need it
 
   action init = {
     // TODO: Change next line according to fund expectations
@@ -172,7 +172,7 @@ module oaksecurity_cosmwasm_ctf_05 {
     val info = { sender: sender, funds: funds }
 
     pure val message: InstantiateMsg = { owner: "" }
-    pure val r = instantiate(init_contract_state, { block: { time: 0 } }, info, message)
+    pure val r = instantiate(init_contract_state, { block: { time: 0, height: 1 } }, info, message)
 
     all {
       contract_state' = r._2,

--- a/tests/snapshots/integration_tests__ctf05.snap
+++ b/tests/snapshots/integration_tests__ctf05.snap
@@ -137,8 +137,8 @@ module oaksecurity_cosmwasm_ctf_05 {
     balances: Addr -> int
   }
 
-  pure val init_contract_state = {
-    state: { current_owner: "s1", proposed_owner: "<missing-value>" },
+  pure val init_contract_state: ContractState = {
+    state: { current_owner: "s1", proposed_owner: None },
     balances: Map()
   }
 

--- a/tests/snapshots/integration_tests__ctf05.snap
+++ b/tests/snapshots/integration_tests__ctf05.snap
@@ -138,7 +138,7 @@ module oaksecurity_cosmwasm_ctf_05 {
   }
 
   pure val init_contract_state = {
-    state: { current_owner: "s1",proposed_owner: <missing-type> },
+    state: { current_owner: "s1", proposed_owner: "<missing-value>" },
     balances: Map()
   }
 

--- a/tests/snapshots/integration_tests__ctf06.snap
+++ b/tests/snapshots/integration_tests__ctf06.snap
@@ -109,7 +109,7 @@ module oaksecurity_cosmwasm_ctf_06 {
     proposal: Proposal
   }
 
-  pure val init_contract_state = {
+  pure val init_contract_state: ContractState = {
     config: { voting_window: 0, voting_token: "s1", owner: "s1" },
     proposal: { proposer: "s1", timestamp: 0 }
   }

--- a/tests/snapshots/integration_tests__ctf06.snap
+++ b/tests/snapshots/integration_tests__ctf06.snap
@@ -110,8 +110,8 @@ module oaksecurity_cosmwasm_ctf_06 {
   }
 
   pure val init_contract_state = {
-    config: { voting_window: 0,voting_token: "s1",owner: "s1" },
-    proposal: { proposer: "s1",timestamp: 0 }
+    config: { voting_window: 0, voting_token: "s1", owner: "s1" },
+    proposal: { proposer: "s1", timestamp: 0 }
   }
 
   action execute_step = all {
@@ -141,7 +141,7 @@ module oaksecurity_cosmwasm_ctf_06 {
     val funds = [{ denom: denom, amount: amount }]
     val info = { sender: sender, funds: funds }
 
-    pure val message: InstantiateMsg = { token: "",owner: "",window: 0 }
+    pure val message: InstantiateMsg = { token: "", owner: "", window: 0 }
     pure val r = instantiate(init_contract_state, { block: { time: 0, height: 1 } }, info, message)
 
     all {

--- a/tests/snapshots/integration_tests__ctf06.snap
+++ b/tests/snapshots/integration_tests__ctf06.snap
@@ -35,7 +35,7 @@ module oaksecurity_cosmwasm_ctf_06 {
   type ExecuteMsg =
     | ExecuteMsg_Propose
     | ExecuteMsg_ResolveProposal
-    | ExecuteMsg_OwnerAction({ action: CosmosMsg })
+    | ExecuteMsg_OwnerAction({ action_: CosmosMsg })
     | ExecuteMsg_Receive(Cw20ReceiveMsg)
   type Cw20HookMsg =
     | Cw20HookMsg_CastVote
@@ -47,7 +47,7 @@ module oaksecurity_cosmwasm_ctf_06 {
   pure def execute(state: ContractState, env: Env, info: MessageInfo, msg: ExecuteMsg): (Result[Response, ContractError], ContractState) = match msg {
     | ExecuteMsg_Propose(__r) => propose(state, env, info)
     | ExecuteMsg_ResolveProposal(__r) => resolve_proposal(state, env, info)
-    | ExecuteMsg_OwnerAction(__r) => owner_action(state, info, __r.action)
+    | ExecuteMsg_OwnerAction(__r) => owner_action(state, info, __r.action_)
     | ExecuteMsg_Receive(msg) => receive_cw20(state, env, info, msg)
   }
 
@@ -98,8 +98,8 @@ module oaksecurity_cosmwasm_ctf_06 {
   action owner_action_action = {
     // TODO: Change next line according to fund expectations
     pure val max_funds = MAX_AMOUNT
-    nondet message_action: CosmosMsg = <missing-nondet-value>.oneOf()
-    pure val message: ExecuteMsg = ExecuteMsg_OwnerAction({ action: message_action })
+    nondet message_action_: CosmosMsg = "<missing-nondet-value>".oneOf()
+    pure val message: ExecuteMsg = ExecuteMsg_OwnerAction({ action_: message_action_ })
     execute_message(message, max_funds)
   }
   pure val DENOM = "uawesome"
@@ -129,7 +129,7 @@ module oaksecurity_cosmwasm_ctf_06 {
 
   pure val init_bank_state = ADDRESSES.mapBy(_ => DENOMS.mapBy(_ => MAX_AMOUNT))
 
-  val env_val = { block: { time: time } }
+  val env_val = { block: { time: time, height: 1 } } // TODO: Add a height var if you need it
 
   action init = {
     // TODO: Change next line according to fund expectations
@@ -142,7 +142,7 @@ module oaksecurity_cosmwasm_ctf_06 {
     val info = { sender: sender, funds: funds }
 
     pure val message: InstantiateMsg = { token: "",owner: "",window: 0 }
-    pure val r = instantiate(init_contract_state, { block: { time: 0 } }, info, message)
+    pure val r = instantiate(init_contract_state, { block: { time: 0, height: 1 } }, info, message)
 
     all {
       contract_state' = r._2,
@@ -245,7 +245,7 @@ pub mod state_structs {
         pub amount: Option<BigInt>,
         
         #[serde(with = "As::<de::Option::<_>>")]
-        pub message_action: Option<CosmosMsg>
+        pub message_action_: Option<CosmosMsg>
     }
     
     #[derive(Clone, Debug, Deserialize)]
@@ -444,8 +444,8 @@ pub mod tests {
                     let sender = Addr::unchecked(sender.unwrap());
                     let funds = funds_from_trace(amount, denom);
 
-                    let message_action = nondet_picks.message_action.clone().unwrap();
-                    let msg = ExecuteMsg::OwnerAction { action: message_action };
+                    let message_action_ = nondet_picks.message_action_.clone().unwrap();
+                    let msg = ExecuteMsg::OwnerAction { action_: message_action_ };
                     println!("Message: {:?}", msg);
                     println!("Sender: {:?}", sender);
                     println!("Funds: {:?}", funds);

--- a/tests/snapshots/integration_tests__ctf07.snap
+++ b/tests/snapshots/integration_tests__ctf07.snap
@@ -142,7 +142,7 @@ module oaksecurity_cosmwasm_ctf_07 {
     val funds = [{ denom: denom, amount: amount }]
     val info = { sender: sender, funds: funds }
 
-    pure val message: InstantiateMsg = { owner: "",threshold: 0 }
+    pure val message: InstantiateMsg = { owner: "", threshold: 0 }
     pure val r = instantiate(init_contract_state, { block: { time: 0, height: 1 } }, info, message)
 
     all {

--- a/tests/snapshots/integration_tests__ctf07.snap
+++ b/tests/snapshots/integration_tests__ctf07.snap
@@ -108,7 +108,7 @@ module oaksecurity_cosmwasm_ctf_07 {
     balances: Addr -> int
   }
 
-  pure val init_contract_state = {
+  pure val init_contract_state: ContractState = {
     top_depositor: "s1",
     owner: "s1",
     threshold: 0,

--- a/tests/snapshots/integration_tests__ctf07.snap
+++ b/tests/snapshots/integration_tests__ctf07.snap
@@ -95,7 +95,7 @@ module oaksecurity_cosmwasm_ctf_07 {
   action owner_action_action = {
     // TODO: Change next line according to fund expectations
     pure val max_funds = MAX_AMOUNT
-    nondet message_msg: CosmosMsg = <missing-nondet-value>.oneOf()
+    nondet message_msg: CosmosMsg = "<missing-nondet-value>".oneOf()
     pure val message: ExecuteMsg = ExecuteMsg_OwnerAction({ msg: message_msg })
     execute_message(message, max_funds)
   }
@@ -130,7 +130,7 @@ module oaksecurity_cosmwasm_ctf_07 {
 
   pure val init_bank_state = ADDRESSES.mapBy(_ => DENOMS.mapBy(_ => MAX_AMOUNT))
 
-  val env_val = { block: { time: time } }
+  val env_val = { block: { time: time, height: 1 } } // TODO: Add a height var if you need it
 
   action init = {
     // TODO: Change next line according to fund expectations
@@ -143,7 +143,7 @@ module oaksecurity_cosmwasm_ctf_07 {
     val info = { sender: sender, funds: funds }
 
     pure val message: InstantiateMsg = { owner: "",threshold: 0 }
-    pure val r = instantiate(init_contract_state, { block: { time: 0 } }, info, message)
+    pure val r = instantiate(init_contract_state, { block: { time: 0, height: 1 } }, info, message)
 
     all {
       contract_state' = r._2,

--- a/tests/snapshots/integration_tests__ctf08.snap
+++ b/tests/snapshots/integration_tests__ctf08.snap
@@ -176,7 +176,7 @@ module oaksecurity_cosmwasm_ctf_08 {
 
   pure val init_bank_state = ADDRESSES.mapBy(_ => DENOMS.mapBy(_ => MAX_AMOUNT))
 
-  val env_val = { block: { time: time } }
+  val env_val = { block: { time: time, height: 1 } } // TODO: Add a height var if you need it
 
   action init = {
     // TODO: Change next line according to fund expectations
@@ -189,7 +189,7 @@ module oaksecurity_cosmwasm_ctf_08 {
     val info = { sender: sender, funds: funds }
 
     pure val message: InstantiateMsg = { nft_address: "" }
-    pure val r = instantiate(init_contract_state, { block: { time: 0 } }, info, message)
+    pure val r = instantiate(init_contract_state, { block: { time: 0, height: 1 } }, info, message)
 
     all {
       contract_state' = r._2,

--- a/tests/snapshots/integration_tests__ctf08.snap
+++ b/tests/snapshots/integration_tests__ctf08.snap
@@ -157,7 +157,7 @@ module oaksecurity_cosmwasm_ctf_08 {
     config: { nft_contract: "s1" },
     sales: Map(),
     trades: Map(),
-    operations: { n_trades: 0,n_sales: 0 }
+    operations: { n_trades: 0, n_sales: 0 }
   }
 
   action execute_step = all {

--- a/tests/snapshots/integration_tests__ctf08.snap
+++ b/tests/snapshots/integration_tests__ctf08.snap
@@ -153,7 +153,7 @@ module oaksecurity_cosmwasm_ctf_08 {
     operations: Operations
   }
 
-  pure val init_contract_state = {
+  pure val init_contract_state: ContractState = {
     config: { nft_contract: "s1" },
     sales: Map(),
     trades: Map(),

--- a/tests/snapshots/integration_tests__ctf09.snap
+++ b/tests/snapshots/integration_tests__ctf09.snap
@@ -109,7 +109,7 @@ module oaksecurity_cosmwasm_ctf_09 {
   }
 
   pure val init_contract_state = {
-    state: { owner: "s1",total_staked: 0,global_index: 0 },
+    state: { owner: "s1", total_staked: 0, global_index: 0 },
     users: Map()
   }
 

--- a/tests/snapshots/integration_tests__ctf09.snap
+++ b/tests/snapshots/integration_tests__ctf09.snap
@@ -108,7 +108,7 @@ module oaksecurity_cosmwasm_ctf_09 {
     users: Addr -> UserRewardInfo
   }
 
-  pure val init_contract_state = {
+  pure val init_contract_state: ContractState = {
     state: { owner: "s1", total_staked: 0, global_index: 0 },
     users: Map()
   }

--- a/tests/snapshots/integration_tests__ctf09.snap
+++ b/tests/snapshots/integration_tests__ctf09.snap
@@ -128,7 +128,7 @@ module oaksecurity_cosmwasm_ctf_09 {
 
   pure val init_bank_state = ADDRESSES.mapBy(_ => DENOMS.mapBy(_ => MAX_AMOUNT))
 
-  val env_val = { block: { time: time } }
+  val env_val = { block: { time: time, height: 1 } } // TODO: Add a height var if you need it
 
   action init = {
     // TODO: Change next line according to fund expectations
@@ -141,7 +141,7 @@ module oaksecurity_cosmwasm_ctf_09 {
     val info = { sender: sender, funds: funds }
 
     pure val message: InstantiateMsg = {  }
-    pure val r = instantiate(init_contract_state, { block: { time: 0 } }, info, message)
+    pure val r = instantiate(init_contract_state, { block: { time: 0, height: 1 } }, info, message)
 
     all {
       contract_state' = r._2,

--- a/tests/snapshots/integration_tests__ctf10.snap
+++ b/tests/snapshots/integration_tests__ctf10.snap
@@ -83,7 +83,7 @@ module oaksecurity_cosmwasm_ctf_10 {
 
   pure val init_bank_state = ADDRESSES.mapBy(_ => DENOMS.mapBy(_ => MAX_AMOUNT))
 
-  val env_val = { block: { time: time } }
+  val env_val = { block: { time: time, height: 1 } } // TODO: Add a height var if you need it
 
   action init = {
     // TODO: Change next line according to fund expectations
@@ -96,7 +96,7 @@ module oaksecurity_cosmwasm_ctf_10 {
     val info = { sender: sender, funds: funds }
 
     pure val message: InstantiateMsg = { cw721_code_id: 0,mint_per_user: 0,whitelisted_users: [] }
-    pure val r = instantiate(init_contract_state, { block: { time: 0 } }, info, message)
+    pure val r = instantiate(init_contract_state, { block: { time: 0, height: 1 } }, info, message)
 
     all {
       contract_state' = r._2,

--- a/tests/snapshots/integration_tests__ctf10.snap
+++ b/tests/snapshots/integration_tests__ctf10.snap
@@ -68,7 +68,7 @@ module oaksecurity_cosmwasm_ctf_10 {
   }
 
   pure val init_contract_state = {
-    config: { nft_contract: "s1",mint_per_user: 0,total_tokens: 0 },
+    config: { nft_contract: "s1", mint_per_user: 0, total_tokens: 0 },
     whitelist: { users: [] }
   }
 
@@ -95,7 +95,7 @@ module oaksecurity_cosmwasm_ctf_10 {
     val funds = [{ denom: denom, amount: amount }]
     val info = { sender: sender, funds: funds }
 
-    pure val message: InstantiateMsg = { cw721_code_id: 0,mint_per_user: 0,whitelisted_users: [] }
+    pure val message: InstantiateMsg = { cw721_code_id: 0, mint_per_user: 0, whitelisted_users: [] }
     pure val r = instantiate(init_contract_state, { block: { time: 0, height: 1 } }, info, message)
 
     all {

--- a/tests/snapshots/integration_tests__ctf10.snap
+++ b/tests/snapshots/integration_tests__ctf10.snap
@@ -67,7 +67,7 @@ module oaksecurity_cosmwasm_ctf_10 {
     whitelist: Whitelist
   }
 
-  pure val init_contract_state = {
+  pure val init_contract_state: ContractState = {
     config: { nft_contract: "s1", mint_per_user: 0, total_tokens: 0 },
     whitelist: { users: [] }
   }


### PR DESCRIPTION
Hello :octocat: 

By trying the tool on a real-world contract, there is a bunch of small silly syntax/name errors that get in the way of figuring out what actually needs fixing. This PR addresses that by solving or avoiding a number of those problems, so the resulting model only has errors for things that are not trivial to fix.

Unfortunately, our test suite doesn't cover a lot of those. I need to introduce something like a "Super Contract" to our fixtures, so I can add cases for all of this things to it. This work was just a 1-day spike, and I don't really have time to set that up at this time.

Some of the fixes are:
1. Wrap outputs like `<missing-type>` in quotes or use another value supported by Quint syntax so these don't result in syntax errors (that mess up Quint error reporting many times)
2. Prevent scenarios like `[, foo, bar]` by filtering out empty strings in `translate_list` and others, as we use empty string for untranslated cases (i.e. Lifetimes)
3. Support generics (at least the common case).
4. Add `height` to `BlockInfo` since many contracts use that
5. Create dummy types for completeness, so we have a way to translate useless things in a way it doesn't break the model: `TraitObject`, `MultiIndex` and `IndexedMap`. Also stop translating definitions that are *only* about indexes as they are completely useless in the model.
6. Sanitize names that are reserved keywords in quint (i.e. `action`)(Closes https://github.com/informalsystems/cosmwasm-to-quint/issues/11)
7. Improve initialization so we can generate types for enums and values that have type aliases as their type.